### PR TITLE
Refactor: Use relative paths, update README, and remove API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,75 @@
-## Supervised Contrastive Framework for Re-Identification with Inpainting 
+## Supervised Contrastive Framework for Re-Identification with Inpainting
 
 <hr>
 
-- This repository implements a Supervised Contrastive Framework for Re-Identification with Inpainting, leveraging ResNet as backbone model. The framework integrates inpainting techniques and custom augmentations, enhancing feature robustness and re-identification accuracy. The pipeline is designed for end-to-end learning and supports image preprocessing, feature extraction, and feature dimensionality reduction.
+This repository implements a Supervised Contrastive Framework for Re-Identification (Re-ID) with Inpainting. The framework leverages ResNet backbone models, integrates inpainting techniques, and applies custom augmentations to enhance feature robustness and re-identification accuracy. The pipeline is designed for end-to-end learning, encompassing image preprocessing, feature extraction, and model training.
 
-## Augmentations 📘
-The framework applies the following augmentations during preprocessing to improve model generalization and robustness.
+## Project Structure
 
-## Feature Extraction 📘
-- Backbone Model: Supports ResNet-50 and Vision Transformer (ViT) for feature extraction.
-- Projection Head: Reduces feature dimensionality using a two-layer projection head, improving computational efficiency while preserving feature quality.
+The data for this project should be organized under a directory named `REID_scratch` at the root of the project. The expected subdirectory structure is as follows:
+
+```
+REID_scratch/
+├── Market-1501/
+│   └── bounding_box_train/  # Original training images
+└── LSMA_trial/
+    └── new_one/
+        ├── sam2_masks/               # Mask images
+        └── aug_sam2_resize_normalize/ # Inpainted images
+```
+
+## Workflow Overview
+
+The training process consists of two main phases:
+
+1.  **Phase 1: Contrastive Learning**
+    *   This phase pre-trains the `ResNetFeatureExtractor` (encoder) using a contrastive learning approach.
+    *   The `ContrastivePhase` class manages this stage.
+    *   The primary loss function used is `SupConLoss` (Supervised Contrastive Loss), which helps in learning discriminative features by pulling samples from the same class closer in the embedding space while pushing samples from different classes apart.
+
+2.  **Phase 2: Supervised Learning**
+    *   In this phase, the pre-trained encoder is fine-tuned, and a classifier head is trained for the Re-ID task.
+    *   The `SupervisedContrastiveEngine` class orchestrates this stage.
+    *   The loss function combines cross-entropy loss (for the classification task) and the contrastive loss (to retain the benefits of the learned discriminative features).
+
+### Key Modules and Classes:
+
+*   **`main.py`**: Orchestrates the two training phases, from data loading to model training and saving.
+*   **`model.py`**: Defines the `ResNetFeatureExtractor`, which serves as the backbone for feature extraction. It can be configured to use different ResNet versions (e.g., ResNet-101).
+*   **`dataset.py`**:
+    *   Contains `CustomDataManager` for loading and preparing the data for both training phases.
+    *   Implements `ContrastiveTransformations`, which include a variety of data augmentations crucial for robust feature learning. These augmentations include:
+        *   Random Horizontal Flip
+        *   Color Jitter (adjusting brightness, contrast, saturation, hue)
+        *   Random Rotation
+        *   Cutout (randomly masking out regions of the image)
+        *   Random Boxes (overlaying random boxes on images)
+        *   Special handling for incorporating inpainted images alongside original and masked images.
+*   **`config.py`**: Manages all configuration parameters for the project, such as learning rates, batch sizes, model choices, and data paths.
+
+## Feature Extraction
+
+*   **Backbone Model**: Utilizes ResNet models (e.g., ResNet-101, configurable via `CONFIG["backbone"]` in `config.py`) for powerful feature extraction from images.
+*   **Projection Head**: Optionally, a projection head can be used (common in contrastive learning setups) to transform features before the contrastive loss calculation, though the primary focus is on the encoder's features for the downstream classification task.
 
 <hr>
 
-## Installation 
+## Installation
 
-- 1. Clone this repository
-```bash
-git clone https://github.com/mAn-He/CMU24_LSMA_KC.git 
-cd CMU24_LSMA_KC
-```
+1.  Clone this repository:
+    ```bash
+    git clone https://github.com/mAn-He/CMU24_LSMA_KC.git
+    cd CMU24_LSMA_KC
+    ```
 
-- 2. Install the required dependencies:
-```bash
-pip install -r requierments.txt
-```
+2.  Install the required dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+    *(Note: Ensure a `requirements.txt` file is present in the repository for this command to work.)*
 
-### Tihs is LSMA Project Repository. 
-### Made by Hyeonbin, Yongsik, Hoseung. :) Thanks.
+### Weights & Biases (WandB) Configuration:
+This project uses WandB for experiment tracking. After installation, when you run the main script (`main.py`), you might be prompted to log in to WandB if your API key is not already configured locally. Alternatively, you can set the `WANDB_API_KEY` environment variable with your API key before running the script.
+
+### LSMA Project Repository
+Made by Hyeonbin, Yongsik, Hoseung. Thanks!

--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ This project uses WandB for experiment tracking. After installation, when you ru
 
 ### LSMA Project Repository
 Made by Hyeonbin, Yongsik, Hoseung. Thanks!
+Upgrade ..ing

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 # main.py
+import os
 import torch
 from accelerate import Accelerator
 import wandb
@@ -12,14 +13,15 @@ from config import CONFIG
 
 # Initialize WandB
 
-wandb.login(key="4479360fe28288a4508a4ee8b76be303493e3ab1") 
+wandb.login() 
 wandb.init(project=CONFIG["project_name"], config=CONFIG)
 config = wandb.config
 
 # Data paths
-ORIGINAL_DIR = '/home/fisher/fisher/Peoples/hseung/카네기/LSMA/Project/ReIDataset/Market-1501/bounding_box_train'
-MASK_DIR = '/home/fisher/fisher/Peoples/hseung/카네기/LSMA/Project/LSMA_trial/new_one/sam2_masks'
-INPAINTED_DIR = '/home/fisher/fisher/Peoples/hseung/카네기/LSMA/Project/LSMA_trial/new_one/aug_sam2_resize_normalize'
+BASE_DATA_DIR = 'REID_scratch'
+ORIGINAL_DIR = os.path.join(BASE_DATA_DIR, 'Market-1501/bounding_box_train')
+MASK_DIR = os.path.join(BASE_DATA_DIR, 'LSMA_trial/new_one/sam2_masks')
+INPAINTED_DIR = os.path.join(BASE_DATA_DIR, 'LSMA_trial/new_one/aug_sam2_resize_normalize')
 
 # Data loaders
 datamanager = CustomDataManager(ORIGINAL_DIR, MASK_DIR, INPAINTED_DIR,


### PR DESCRIPTION
- I changed absolute data paths in main.py to use relative paths based on a 'REID_scratch' base directory.
- I removed the hardcoded WandB API key from main.py. You will now be prompted or can use environment variables.
- I significantly updated README.md:
    - Added Project Structure section for data organization.
    - Added Workflow Overview section explaining the codebase.
    - Corrected Feature Extraction details.
    - Improved Installation instructions and added a note on WandB API key.
    - Made general improvements to clarity and accuracy.